### PR TITLE
Change agent to use on-demand instances and terminate orphan instances

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -69,6 +69,7 @@ locals {
       gitlab_runner_run_untagged              = var.gitlab_runner_registration_config["run_untagged"]
       gitlab_runner_maximum_timeout           = var.gitlab_runner_registration_config["maximum_timeout"]
       gitlab_runner_access_level              = lookup(var.gitlab_runner_registration_config, "access_level", "not_protected")
+      runners_security_group_id               = aws_security_group.docker_machine.id
   })
 
   template_runner_config = templatefile("${path.module}/template/runner-config.tpl",
@@ -179,9 +180,7 @@ resource "aws_autoscaling_group" "gitlab_runner_instance" {
     }
 
     instances_distribution {
-      spot_instance_pools                      = 3
-      on_demand_base_capacity                  = 0
-      on_demand_percentage_above_base_capacity = 0
+      on_demand_percentage_above_base_capacity = 100
     }
   }
 


### PR DESCRIPTION
## Description
1-The module started to provision the agents using spot instances since moved to use Auto Scaling Group in this merge.
https://github.com/DNXLabs/terraform-aws-gitlab-runner/commit/3a2f39681d3dd2bc2f6327e10269e85a638d3e73
Changed to use on-demand instances and reduce the frequency of having orphan runners.

2-The orphan runners were not destroyed, accumulating in the account.
Script included in user-data, to verify and destroy orphan runners when provisioning new agents.