### PR TITLE
bugfix: userdata template for EIP attachment

### DIFF
--- a/template/eip.tpl
+++ b/template/eip.tpl
@@ -1,9 +1,9 @@
 echo 'installing additional software for assigning EIP'
 
 curl --fail --retry 6 -O https://bootstrap.pypa.io/get-pip.py
-python get-pip.py --user
+python3 get-pip.py --user
 export PATH=~/.local/bin:$PATH
 
 pip install aws-ec2-assign-elastic-ip
 export AWS_DEFAULT_REGION=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | grep region | awk -F\" '{print $4}')
-/bin/aws-ec2-assign-elastic-ip --valid-ips ${eip}
+/usr/local/bin/aws-ec2-assign-elastic-ip --valid-ips ${eip}


### PR DESCRIPTION
Fix userdata template script for EIP attachment.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the CONTRIBUTING.md doc.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

Fix the following errors:
```
# python get-pip.py --user
ERROR: This script does not work on Python 2.7 The minimum supported Python version is 3.6. Please use https://bootstrap.pypa.io/pip/2.7/get-pip.py instead.
```
And:
```
# /bin/aws-ec2-assign-elastic-ip --valid-ips a.b.c.d
-bash: /bin/aws-ec2-assign-elastic-ip: No such file or directory
```
