### PR TITLE
bugfix: removal of docker socket from runners volumes

### DIFF
--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -18,7 +18,7 @@ check_interval = 0
     image = "${runners_image}"
     privileged = ${runners_privileged}
     disable_cache = false
-    volumes = ["/var/run/docker.sock:/var/run/docker.sock", "/cache", "/builds:/builds"${runners_additional_volumes}]
+    volumes = ["/cache"${runners_additional_volumes}]
     shm_size = ${runners_shm_size}
     pull_policy = "${runners_pull_policy}"
   [runners.docker.tmpfs]


### PR DESCRIPTION
The bind of the Docker socket `/var/run/docker.sock:/var/run/docker.sock` is causing timeout in runners startup:

```
*** WARNING: Service runner-xxxxx probably didn't start properly.
Health check error:
start service container: Error response from daemon: Cannot link to a non running container: /runner-xxxxx AS /runner-xxxxx-docker-0-wait-for-service/service (docker.go:1299:0s)
Service container logs:
2022-01-11T13:31:07.727900172Z time="2022-01-11T13:31:07.727643301Z" level=warning msg="could not change group /var/run/docker.sock to docker: group docker not found"
2022-01-11T13:31:07.727946564Z can't create unix socket /var/run/docker.sock: device or resource busy
```

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
